### PR TITLE
Fix CORS by allowing OPTIONS requests through auth filter

### DIFF
--- a/src/main/java/com/recipe/storage/filter/FirebaseAuthenticationFilter.java
+++ b/src/main/java/com/recipe/storage/filter/FirebaseAuthenticationFilter.java
@@ -33,6 +33,12 @@ public class FirebaseAuthenticationFilter extends OncePerRequestFilter {
       @NonNull HttpServletResponse response,
       @NonNull FilterChain filterChain) throws ServletException, IOException {
 
+    // Skip auth for OPTIONS requests (CORS preflight)
+    if ("OPTIONS".equals(request.getMethod())) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
     // Skip auth for health check
     if (request.getRequestURI().contains("/actuator/health")) {
       filterChain.doFilter(request, response);


### PR DESCRIPTION
## Problem
CORS preflight requests (OPTIONS) were being blocked by the Firebase authentication filter, causing the following error when calling the API from localhost:

```
Access to XMLHttpRequest at 'https://recipe-storage-service-341866919859.europe-west2.run.app/api/recipes' from origin 'http://localhost:5173' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

## Solution
- Skip authentication for OPTIONS requests (CORS preflight) in `FirebaseAuthenticationFilter`
- This allows browsers to verify CORS configuration before sending actual authenticated requests
- OPTIONS requests don't need authentication since they don't access any resources

## Testing
- Local frontend can now call the storage service API without CORS errors
- Actual POST/GET requests still require Firebase authentication
- OPTIONS requests pass through and return CORS headers from `CorsConfig`