### PR TITLE
Refactor: Cloud Build only builds and pushes images

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -67,7 +67,7 @@ steps:
 
   # Note: Cloud Run deployment is managed by Terraform
   # After image is pushed, trigger Terraform apply to update the service
-  # See: recipe-management-infrastructure/terraform/environments/dev/main.tf
+  # See: recipe-management-infrastructure/terraform/environments/*/main.tf
 
 # Substitutions for different environments
 substitutions:


### PR DESCRIPTION
## Changes

Removes the `gcloud run deploy` step from Cloud Build pipeline. Deployment is now managed by Terraform.

## Why

**Separation of concerns:**
- **Cloud Build** (CI): Build & test code, push images
- **Terraform** (IaC): Manage infrastructure configuration

**Problems with current approach:**
- Configuration hardcoded in Cloud Build YAML
- Can't manage dev/staging/prod differently  
- Terraform exists but isn't used (drift)
- Two sources of truth for same service

## What Cloud Build Now Does

✅ Run tests and linting
✅ Build application JAR
✅ Build Docker image
✅ Push to Artifact Registry

❌ ~~Deploy to Cloud Run~~ (moved to Terraform)

## New Deployment Flow

1. **Cloud Build**: Push image to Artifact Registry (this repo)
2. **Terraform apply**: Update Cloud Run service (infrastructure repo)

See: `recipe-management-infrastructure/terraform/environments/dev/main.tf`

## Benefits

- Single source of truth for service config (Terraform)
- Environment-specific configs easy to manage
- No configuration drift
- Proper infrastructure-as-code

## Related

- Infrastructure PR: Adds Cloud Run Terraform resources
- AI Service PR: Same refactor

## Testing

- [ ] Cloud Build successfully builds and pushes image
- [ ] Terraform apply updates service with new image