### PR TITLE
Fix: GET recipes CORS and Firestore query optimization

### DIFF
--- a/src/main/java/com/recipe/storage/config/CorsConfig.java
+++ b/src/main/java/com/recipe/storage/config/CorsConfig.java
@@ -22,6 +22,7 @@ public class CorsConfig {
         registry.addMapping("/**")
             .allowedOrigins(
                 "http://localhost:5173", // Local development
+                "http://localhost:5174", // Local development (alt port)
                 "https://recipe-mgmt-dev.web.app", // Firebase Hosting (dev)
                 "https://recipe-mgmt-dev.firebaseapp.com" // Firebase Hosting (dev alt)
             )

--- a/src/main/java/com/recipe/storage/filter/FirebaseAuthenticationFilter.java
+++ b/src/main/java/com/recipe/storage/filter/FirebaseAuthenticationFilter.java
@@ -26,6 +26,7 @@ public class FirebaseAuthenticationFilter extends OncePerRequestFilter {
   private static final String BEARER_PREFIX = "Bearer ";
   private static final List<String> ALLOWED_ORIGINS = List.of(
       "http://localhost:5173",
+      "http://localhost:5174",
       "https://recipe-mgmt-dev.web.app",
       "https://recipe-mgmt-dev.firebaseapp.com"
   );

--- a/src/main/java/com/recipe/storage/service/RecipeService.java
+++ b/src/main/java/com/recipe/storage/service/RecipeService.java
@@ -130,9 +130,11 @@ public class RecipeService {
     }
     
     try {
+      // Note: Removed orderBy to avoid needing composite index
+      // Recipes are returned in document creation order
+      // TODO: Add composite index and re-enable orderBy for better UX
       Query query = firestore.collection(recipesCollection)
-          .whereEqualTo("userId", userId)
-          .orderBy("createdAt", Query.Direction.DESCENDING);
+          .whereEqualTo("userId", userId);
       
       ApiFuture<QuerySnapshot> future = query.get();
       QuerySnapshot querySnapshot = future.get();
@@ -142,6 +144,9 @@ public class RecipeService {
         Recipe recipe = doc.toObject(Recipe.class);
         recipes.add(mapToResponse(recipe));
       });
+      
+      // Sort in-memory by createdAt (newest first)
+      recipes.sort((a, b) -> b.getCreatedAt().compareTo(a.getCreatedAt()));
       
       log.info("Found {} recipes for user {}", recipes.size(), userId);
       return recipes;


### PR DESCRIPTION
## Changes

1. **Add localhost:5174 to CORS origins** - Allows dev server on alternate port
2. **Optimize getUserRecipes query** - Removed  to avoid requiring composite Firestore index, sort in-memory instead

## Problem

GET  was failing with:
- CORS error from  (not in allowed origins)
- 500 error due to missing Firestore composite index for 

## Solution

- Added  to both CorsConfig and FirebaseAuthenticationFilter
- Removed  from Firestore query, sort results in-memory by 

## Testing

- [ ] Verify GET request works from 
- [ ] Verify recipes returned in correct order (newest first)