### PR TITLE
Add automatic image deployment to Cloud Build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -65,9 +65,26 @@ steps:
         docker push ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY_REPO}/${_SERVICE_NAME}:${SHORT_SHA}
         docker push ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY_REPO}/${_SERVICE_NAME}:latest
 
-  # Note: Cloud Run deployment is managed by Terraform
-  # After image is pushed, trigger Terraform apply to update the service
-  # See: recipe-management-infrastructure/terraform/environments/*/main.tf
+  # Deploy new image to Cloud Run - ONLY on main branch
+  # Note: Only updates the image, other config managed by Terraform
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    id: 'deploy-storage'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        # Only deploy on main branch
+        if [ "$BRANCH_NAME" != "main" ]; then
+          echo "PR build detected (branch: $BRANCH_NAME), skipping deployment"
+          exit 0
+        fi
+        
+        echo "Deploying new image to Cloud Run..."
+        gcloud run services update ${_SERVICE_NAME} \
+          --image ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY_REPO}/${_SERVICE_NAME}:latest \
+          --region ${_REGION}
+        
+        echo "Deployment complete ✓"
 
 # Substitutions for different environments
 substitutions:


### PR DESCRIPTION
## Changes

Adds deployment step back to Cloud Build that automatically updates the Cloud Run service with the new image after push.

## Why

After the refactor removing deployment, images were built and pushed but never deployed automatically. This restores automatic deployment while maintaining Terraform as the source of truth for configuration.

## How It Works

```yaml
gcloud run services update recipe-storage-service \
  --image <new-image> \
  --region europe-west2
```

**Key points:**
- Only updates the **image** (not CPU, memory, env vars, etc.)
- Configuration still managed by Terraform
- Automatic deployment on merge to main
- Skipped on PR builds

## Benefits

- ✅ Automatic deployment on merge to main
- ✅ No manual intervention needed
- ✅ Terraform still owns configuration
- ✅ Fast deployments (just image update)

## Related

- Supersedes the Terraform-only approach from PR #13
- Works alongside infrastructure PR #22