### PR TITLE
Add automatic deployment step to Cloud Build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -65,9 +65,26 @@ steps:
         docker push ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY_REPO}/${_SERVICE_NAME}:${SHORT_SHA}
         docker push ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY_REPO}/${_SERVICE_NAME}:latest
 
-  # Note: Cloud Run deployment is managed by Terraform
-  # After image is pushed, trigger Terraform apply to update the service
-  # See: recipe-management-infrastructure/terraform/environments/*/main.tf
+  # Deploy new image to Cloud Run - ONLY on main branch
+  # Note: Only updates the image, other config managed by Terraform
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    id: 'deploy-storage'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        # Only deploy on main branch
+        if [ "$BRANCH_NAME" != "main" ]; then
+          echo "PR build detected (branch: $BRANCH_NAME), skipping deployment"
+          exit 0
+        fi
+        
+        echo "Deploying new image to Cloud Run..."
+        gcloud run services update ${_SERVICE_NAME} \
+          --image ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY_REPO}/${_SERVICE_NAME}:latest \
+          --region ${_REGION}
+        
+        echo "Deployment complete ✓"
 
 # Substitutions for different environments
 substitutions:


### PR DESCRIPTION
## Changes

Adds the deployment step to Cloud Build that auto-updates Cloud Run with new images.

## Why

PR #15 was accidentally empty. This PR contains the actual deployment step.

## What It Does

```bash
gcloud run services update recipe-storage-service --image <latest> --region europe-west2
```

Only updates image, Terraform still manages config.