### PR TITLE
Add DELETE endpoint for recipes

### DIFF
--- a/src/main/java/com/recipe/storage/controller/RecipeController.java
+++ b/src/main/java/com/recipe/storage/controller/RecipeController.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -161,5 +162,51 @@ public class RecipeController {
     log.info("Fetching recipe {} for user {}", recipeId, userId);
     RecipeResponse recipe = recipeService.getRecipe(recipeId, userId);
     return ResponseEntity.ok(recipe);
+  }
+
+  /**
+   * Delete a recipe by ID.
+   * Requires Firebase authentication and user must own the recipe.
+   *
+   * @param recipeId The recipe ID to delete
+   * @param userId The authenticated user's Firebase UID (injected by auth filter)
+   * @return 204 No Content on successful deletion
+   */
+  @DeleteMapping("/{recipeId}")
+  @Operation(
+      summary = "Delete a recipe by ID",
+      description = "Deletes a recipe by its ID. User must own the recipe to delete it. "
+          + "Requires Firebase authentication token in Authorization header."
+  )
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "204",
+          description = "Recipe deleted successfully",
+          content = @Content
+      ),
+      @ApiResponse(
+          responseCode = "401",
+          description = "Unauthorized - invalid or missing Firebase token",
+          content = @Content
+      ),
+      @ApiResponse(
+          responseCode = "403",
+          description = "Forbidden - user does not own this recipe",
+          content = @Content
+      ),
+      @ApiResponse(
+          responseCode = "404",
+          description = "Recipe not found",
+          content = @Content
+      )
+  })
+  public ResponseEntity<Void> deleteRecipe(
+      @Parameter(description = "Recipe ID to delete", required = true)
+      @PathVariable String recipeId,
+      @Parameter(hidden = true) @RequestAttribute("userId") String userId) {
+    
+    log.info("Deleting recipe {} for user {}", recipeId, userId);
+    recipeService.deleteRecipe(recipeId, userId);
+    return ResponseEntity.noContent().build();
   }
 }


### PR DESCRIPTION
## Changes

Adds DELETE endpoint to the recipe storage service, allowing users to delete their own recipes.

## API Endpoint

```
DELETE /api/recipes/{recipeId}
Authorization: Bearer <firebase-token>
```

**Responses:**
- `204 No Content` - Recipe deleted successfully
- `401 Unauthorized` - Invalid or missing Firebase token
- `403 Forbidden` - User doesn't own this recipe
- `404 Not Found` - Recipe doesn't exist

## Implementation

### RecipeService
- `deleteRecipe(recipeId, userId)` method
- Verifies recipe exists before deletion
- Enforces ownership check (user can only delete their own recipes)
- Uses Firestore `delete()` operation
- Proper error handling and logging

### RecipeController
- `DELETE /{recipeId}` endpoint
- Returns `204 No Content` on success
- Firebase authentication required
- Full OpenAPI/Swagger documentation
- Consistent with existing GET/POST endpoints

## Security

- ✅ Firebase authentication required
- ✅ Ownership verification (user can only delete their own recipes)
- ✅ Returns 403 if user tries to delete someone else's recipe
- ✅ Proper authorization logging

## Testing

Manual testing required:
- [ ] DELETE existing recipe (should return 204)
- [ ] DELETE non-existent recipe (should return 404)
- [ ] DELETE someone else's recipe (should return 403)
- [ ] DELETE without auth token (should return 401)

## Related

- Frontend PR: theandiman/recipe-management-frontend#12
  - Adds delete button with confirmation dialog to Recipe Library

## Notes

Backend endpoint is ready. Frontend can now successfully delete recipes once both PRs are merged and deployed.