### PR TITLE
fix(dto): keep positive validation but omit zero timings from client

### DIFF
--- a/src/main/java/com/recipe/storage/dto/CreateRecipeRequest.java
+++ b/src/main/java/com/recipe/storage/dto/CreateRecipeRequest.java
@@ -54,13 +54,14 @@ public class CreateRecipeRequest {
   )
   private List<String> instructions;
 
-  @Positive(message = "Prep time must be positive")
-  @Schema(description = "Preparation time in minutes", example = "15")
-  private Integer prepTime;
+    // Timings are optional but if provided must be positive (>0)
+    @Positive(message = "Prep time must be positive")
+    @Schema(description = "Preparation time in minutes", example = "15")
+    private Integer prepTime;
 
-  @Positive(message = "Cook time must be positive")
-  @Schema(description = "Cooking time in minutes", example = "20")
-  private Integer cookTime;
+    @Positive(message = "Cook time must be positive")
+    @Schema(description = "Cooking time in minutes", example = "20")
+    private Integer cookTime;
 
   @NotNull(message = "Servings is required")
   @Positive(message = "Servings must be positive")


### PR DESCRIPTION
Restore @Positive on prepTime/cookTime; frontend now omits zero/negative timings so validation won't fail. This PR contains the DTO change only.