### PR TITLE
docs: Update README with Swagger UI link

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ environment:
 
 ## API Endpoints
 
-📘 **[Is API Documentation](https://theandiman.github.io/recipe-management-storage-service/)** - View the interactive Swagger UI for full API details.
+📘 **[API Documentation](https://theandiman.github.io/recipe-management-storage-service/)** - View the interactive Swagger UI for full API details.
 
 ### Save Recipe
 ```http


### PR DESCRIPTION
Adds a link to the hosted Swagger UI documentation on GitHub Pages to the README.