### PR TITLE
chore: Use shared Renovate config from parent repo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>theandiman/recipe-management"
+  ]
+}


### PR DESCRIPTION
Adopts the shared Renovate configuration from the parent recipe-management repository.

This centralizes dependency update rules, schedules, and automerge policies across all repositories in the monorepo.