### PR TITLE
Fix ZAP scan: remove invalid flags causing error

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -136,6 +136,8 @@ jobs:
         echo "Running OWASP ZAP baseline scan against $SERVICE_URL"
         
         # Run ZAP baseline scan
+        # Exit code 0: Success, 1: At least 1 FAIL, 2: At least 1 WARN and no FAILs, 3: Any other failure
+        # We use '|| true' to prevent workflow failure on warnings/failures
         docker run --rm \
           -v $(pwd):/zap/wrk:rw \
           ghcr.io/zaproxy/zaproxy:stable \
@@ -145,8 +147,7 @@ jobs:
           -m 5 \
           -r zap-report.html \
           -w zap-report.md \
-          -J zap-report.json \
-          -l HIGH -I || true
+          -J zap-report.json || true
         
         echo "ZAP scan complete"
 


### PR DESCRIPTION
## Problem
The ZAP baseline scan is failing with error:
```
Level must be one of ['PASS', 'IGNORE', 'INFO', 'WARN', 'FAIL']
```

## Root Cause
The flags `-l HIGH` and `-I` are invalid for `zap-baseline.py`:
- `-l` expects one of: PASS, IGNORE, INFO, WARN, FAIL (not HIGH)
- `-I` is not a valid flag for baseline scans

## Changes
- ✅ Remove `-l HIGH` flag
- ✅ Remove `-I` flag
- ✅ Add comments explaining exit codes
- ✅ Keep `|| true` to prevent workflow failure on security findings

## Behavior
ZAP will now use default settings and report all findings. The workflow will continue even if security issues are found (non-blocking), but reports will be generated for review.

## Testing
- [ ] Merge and trigger deployment to main
- [ ] Verify ZAP scan completes without errors
- [ ] Confirm reports are generated successfully