### PR TITLE
Remove GCS upload for ZAP reports, use only GitHub Artifacts

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -161,31 +161,6 @@ jobs:
           echo "Check ZAP container output above for errors"
         fi
 
-    - name: Upload ZAP Reports to Cloud Storage
-      if: github.ref == 'refs/heads/main'
-      run: |
-        # Check if reports exist
-        if [ ! -f "zap-reports/zap-report.html" ]; then
-          echo "No ZAP reports found to upload - skipping Cloud Storage upload"
-          exit 0
-        fi
-        
-        # Create bucket if it doesn't exist
-        gsutil mb -p ${{ secrets.GCP_PROJECT_ID }} -l $REGION gs://${{ secrets.GCP_PROJECT_ID }}-security-reports 2>/dev/null || true
-        
-        # Upload reports with timestamp
-        TIMESTAMP=$(date +%Y%m%d-%H%M%S)
-        gsutil -m cp zap-reports/zap-report.* \
-          gs://${{ secrets.GCP_PROJECT_ID }}-security-reports/$SERVICE_NAME/zap/$TIMESTAMP/
-        
-        echo "ZAP reports uploaded to gs://${{ secrets.GCP_PROJECT_ID }}-security-reports/$SERVICE_NAME/zap/$TIMESTAMP/"
-        
-        # Make the HTML report publicly readable
-        gsutil iam ch allUsers:objectViewer \
-          gs://${{ secrets.GCP_PROJECT_ID }}-security-reports/$SERVICE_NAME/zap/$TIMESTAMP/zap-report.html || true
-        
-        echo "View report: https://storage.googleapis.com/${{ secrets.GCP_PROJECT_ID }}-security-reports/$SERVICE_NAME/zap/$TIMESTAMP/zap-report.html"
-
     - name: Upload ZAP Reports as Artifacts
       if: github.ref == 'refs/heads/main' && hashFiles('zap-reports/zap-report.html') != ''
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
Simplify ZAP report storage by removing the Cloud Storage upload step and keeping only GitHub Artifacts.

## Why This Change?
GitHub Artifacts provide everything we need:
- ✅ Easy access from the Actions tab
- ✅ 30 day retention (sufficient for security reports)
- ✅ No additional infrastructure to manage
- ✅ No need for GCS buckets or public permissions
- ✅ Simpler workflow with fewer dependencies

## Changes
- ❌ Removed Cloud Storage upload step
- ✅ Kept GitHub Artifacts upload (30 day retention)

## Access
After deployment, ZAP reports will be available:
- **GitHub Actions Artifacts**: Download from the workflow run page
- **Retention**: 30 days

## Testing
- [ ] Merge and verify reports are available in GitHub Artifacts
- [ ] Confirm no GCS upload occurs