### PR TITLE
Add PATCH method to CORS allowed methods for recipe sharing

### DIFF
--- a/src/main/java/com/recipe/storage/filter/FirebaseAuthenticationFilter.java
+++ b/src/main/java/com/recipe/storage/filter/FirebaseAuthenticationFilter.java
@@ -52,7 +52,8 @@ public class FirebaseAuthenticationFilter extends OncePerRequestFilter {
         String origin = request.getHeader("Origin");
         if (origin != null && ALLOWED_ORIGINS.contains(origin)) {
           response.setHeader("Access-Control-Allow-Origin", origin);
-          response.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+          response.setHeader("Access-Control-Allow-Methods",
+              "GET, POST, PUT, PATCH, DELETE, OPTIONS");
           response.setHeader("Access-Control-Allow-Headers", "*");
           response.setHeader("Access-Control-Allow-Credentials", "true");
           response.setHeader("Access-Control-Max-Age", "3600");

--- a/src/test/java/com/recipe/storage/filter/FirebaseAuthenticationFilterTest.java
+++ b/src/test/java/com/recipe/storage/filter/FirebaseAuthenticationFilterTest.java
@@ -56,7 +56,8 @@ class FirebaseAuthenticationFilterTest {
 
         // Assert
         verify(response).setHeader("Access-Control-Allow-Origin", "http://localhost:5173");
-        verify(response).setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+        verify(response).setHeader("Access-Control-Allow-Methods",
+            "GET, POST, PUT, PATCH, DELETE, OPTIONS");
         verify(response).setHeader("Access-Control-Allow-Headers", "*");
         verify(response).setHeader("Access-Control-Allow-Credentials", "true");
         verify(response).setHeader("Access-Control-Max-Age", "3600");


### PR DESCRIPTION
## Description
This PR fixes a CORS issue preventing the frontend from calling the recipe sharing endpoint.

## Changes
- Updated `FirebaseAuthenticationFilter` to include PATCH in `Access-Control-Allow-Methods` for preflight responses
- Updated test to verify PATCH is allowed in CORS preflight responses
- Fixes: `Method PATCH is not allowed by Access-Control-Allow-Methods in preflight response` error

## Testing
- ✅ All unit tests pass
- ✅ FirebaseAuthenticationFilterTest verifies PATCH is now allowed

## Related
This enables the recipe sharing feature in the frontend (share/unshare button on recipe detail page).