### PR TITLE
fix: respect Cloud Run PORT env var for server port

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 # Application
 spring.application.name=recipe-management-service
-server.port=8081
+server.port=${PORT:8081}
 
 # Firebase Configuration
 firebase.project.id=recipe-mgmt-dev


### PR DESCRIPTION
## Problem

Cloud Run injects a `PORT` environment variable (default `8080`) and health-checks that exact port. The server was hardcoded to `server.port=8081`, so Tomcat bound to 8081 while Cloud Run expected 8080 — causing every deployment to fail with a container startup error.

## Fix

Changed `server.port=8081` → `server.port=${PORT:8081}`

This makes Spring bind to whatever port Cloud Run supplies via the `PORT` env var, while keeping `8081` as a local-development fallback when `PORT` is not set.

## Testing

- Local dev: unaffected (still uses 8081 by default)
- Cloud Run: will now bind to 8080 and pass health checks