### PR TITLE
fix: update CD workflow to use WIF auth

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -31,7 +31,7 @@ jobs:
     name: Deploy
     needs: ci
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    uses: theandiman/recipe-management/.github/workflows/backend-java-cloud-run-cd.yml@973f68b323d96d59ce2ac00723f4ecc641c063f5
+    uses: theandiman/recipe-management/.github/workflows/backend-java-cloud-run-cd.yml@a8f5a790fca8ae758eb5c75115215291b77b61cc
     permissions:
       contents: write
       actions: write
@@ -39,5 +39,6 @@ jobs:
       service_name: recipe-management-service
       artifact_registry_repository: recipe-management
     secrets:
-      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_DEPLOY_SA: ${{ secrets.GCP_DEPLOY_SA }}


### PR DESCRIPTION
Fixes CI/CD deployment failures caused by empty `GCP_SA_KEY` secret.

This service was migrated to Workload Identity Federation (`GCP_WORKLOAD_IDENTITY_PROVIDER` + `GCP_DEPLOY_SA`) but the shared CD workflow was still being called with the old SA key secret, which is empty.

Changes:
- Pin shared workflow ref to `a8f5a79` (WIF support added in recipe-management#6)
- Pass `GCP_WORKLOAD_IDENTITY_PROVIDER` and `GCP_DEPLOY_SA` instead of `GCP_SA_KEY`
