### PR TITLE
fix: pin CD workflow to c9051e1 and pass use_wif: true

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -31,13 +31,14 @@ jobs:
     name: Deploy
     needs: ci
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    uses: theandiman/recipe-management/.github/workflows/backend-java-cloud-run-cd.yml@a8f5a790fca8ae758eb5c75115215291b77b61cc
+    uses: theandiman/recipe-management/.github/workflows/backend-java-cloud-run-cd.yml@c9051e128e0cb76c0f057029629713d0ce1d0565
     permissions:
       contents: write
       actions: write
     with:
       service_name: recipe-management-service
       artifact_registry_repository: recipe-management
+      use_wif: true
     secrets:
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}


### PR DESCRIPTION
Follows on from #135. The previous shared workflow commit (a8f5a79) used `secrets` context in step `if:` expressions which GitHub Actions does not allow in reusable workflows. The new commit (c9051e1) uses a boolean input `use_wif` instead. This PR updates the pin and adds `use_wif: true`.