### PR TITLE
Add Firestore composite index for personalized feed query

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -13,6 +13,24 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "recipes",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "isPublic",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Summary
- Adds missing Firestore composite index for feed query in firestore.indexes.json
- Supports query shape used by /api/feed in RecipeService#getFeed

## Why
Feed requests can fail with FAILED_PRECONDITION: The query requires an index when running:
- whereIn("userId", ...)
- whereEqualTo("isPublic", true)
- orderBy("createdAt", DESC)

## Change
- Added composite index fields:
  - userId ASC
  - isPublic ASC
  - createdAt DESC

## Validation
- Configuration updated; index will be built by Firebase deploy pipeline.